### PR TITLE
Get rid of the allocation in the jack process callback for the example

### DIFF
--- a/example-jack/Cargo.toml
+++ b/example-jack/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 faust-types = { path = "../faust-types" }
 faust-state = { path = "../faust-state" }
 jack = "0.7.0"
-smallvec = "1.6.1"
 rtrb = "0.1.3"
 
 [build-dependencies]

--- a/example-jack/src/jack.rs
+++ b/example-jack/src/jack.rs
@@ -44,14 +44,14 @@ where
 
         for index_port in 0..num_inputs {
             let port = in_ports[index_port].as_slice(ps);
-            for index_sample in 0..buffer_size {
+            for index_sample in 0..len as usize {
                 inputs[index_port][index_sample] = port[index_sample];
             }
         }
 
         for index_port in 0..num_outputs {
             let port = out_ports[index_port].as_mut_slice(ps);
-            for index_sample in 0..buffer_size {
+            for index_sample in 0..len as usize {
                 outputs[index_port][index_sample] = port[index_sample];
             }
         }


### PR DESCRIPTION
As allocations are not realtime safe we should take care that this doesn't happen.

The downside of this change is, that now we are copying the all the audio samples between the jack buffer and the faust buffer. Before we were only copying the pointer to the array. 