### PR TITLE
Add support for UI label metadata

### DIFF
--- a/faust-types/src/lib.rs
+++ b/faust-types/src/lib.rs
@@ -12,7 +12,7 @@ pub use libm;
 pub type F32 = f32;
 pub type F64 = f64;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct ParamIndex(pub i32);
 
 pub struct Soundfile<'a> {


### PR DESCRIPTION
https://faustdoc.grame.fr/manual/syntax/#ui-label-metadata

I implemented ParamsBuilder::declare, which is getting called throug FaustDsp::build_user_interface_static.
![Screenshot_20220723_195909](https://user-images.githubusercontent.com/34889164/180617337-da7c3878-01ef-4973-ba3c-89c1f25a24da.png)

Sadly it's getting called before the actual widget is getting inserted, so declare is inserting a "default" Node.

To make add_widget properly work with this, i had to change it a bit. As it didn't check if the self.inner hashmap already contains a Node with this id. It now checks for this, and if it exists, updates the existing Node.