### PR TITLE
Expose the node's min/max/step

### DIFF
--- a/faust-state/src/lib.rs
+++ b/faust-state/src/lib.rs
@@ -270,6 +270,39 @@ impl Node {
             0.
         }
     }
+
+    /// The minimum value for this parameter.
+    ///
+    /// This value is an indication of the DSP and is not enforced.
+    pub fn min(&self) -> f32 {
+        if let Some(props) = &self.props {
+            props.min
+        } else {
+            0.
+        }
+    }
+
+    /// The maximum value for this parameter.
+    ///
+    /// This value is an indication of the DSP and is not enforced.
+    pub fn max(&self) -> f32 {
+        if let Some(props) = &self.props {
+            props.max
+        } else {
+            0.
+        }
+    }
+
+    /// The precision of the slider.
+    ///
+    /// This value is an indication of the DSP and is not enforced.
+    pub fn step(&self) -> f32 {
+        if let Some(props) = &self.props {
+            props.step
+        } else {
+            0.
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/faust-state/src/lib.rs
+++ b/faust-state/src/lib.rs
@@ -274,33 +274,36 @@ impl Node {
     /// The minimum value for this parameter.
     ///
     /// This value is an indication of the DSP and is not enforced.
-    pub fn min(&self) -> f32 {
+    /// Returns None if there is no minimume, such as a button in the DSP.
+    pub fn min(&self) -> Option<f32> {
         if let Some(props) = &self.props {
-            props.min
+            Some(props.min)
         } else {
-            0.
+            None
         }
     }
 
     /// The maximum value for this parameter.
     ///
     /// This value is an indication of the DSP and is not enforced.
-    pub fn max(&self) -> f32 {
+    /// Returns None if there is no minimume, such as a button in the DSP.
+    pub fn max(&self) -> Option<f32> {
         if let Some(props) = &self.props {
-            props.max
+            Some(props.max)
         } else {
-            0.
+            None
         }
     }
 
     /// The precision of the slider.
     ///
     /// This value is an indication of the DSP and is not enforced.
-    pub fn step(&self) -> f32 {
+    /// Returns None if there is no minimume, such as a button in the DSP.
+    pub fn step(&self) -> Option<f32> {
         if let Some(props) = &self.props {
-            props.step
+            Some(props.step)
         } else {
-            0.
+            None
         }
     }
 }

--- a/faust-state/src/lib.rs
+++ b/faust-state/src/lib.rs
@@ -274,7 +274,7 @@ impl Node {
     /// The minimum value for this parameter.
     ///
     /// This value is an indication of the DSP and is not enforced.
-    /// Returns None if there is no minimume, such as a button in the DSP.
+    /// Returns None if there is no minimum, such as a button in the DSP.
     pub fn min(&self) -> Option<f32> {
         if let Some(props) = &self.props {
             Some(props.min)
@@ -286,7 +286,7 @@ impl Node {
     /// The maximum value for this parameter.
     ///
     /// This value is an indication of the DSP and is not enforced.
-    /// Returns None if there is no minimume, such as a button in the DSP.
+    /// Returns None if there is no maximum, such as a button in the DSP.
     pub fn max(&self) -> Option<f32> {
         if let Some(props) = &self.props {
             Some(props.max)
@@ -298,7 +298,7 @@ impl Node {
     /// The precision of the slider.
     ///
     /// This value is an indication of the DSP and is not enforced.
-    /// Returns None if there is no minimume, such as a button in the DSP.
+    /// Returns None if there is no step, such as a button in the DSP.
     pub fn step(&self) -> Option<f32> {
         if let Some(props) = &self.props {
             Some(props.step)


### PR DESCRIPTION
After creating the DSP, the ability to inspect the State to retrieve the parameter's metadata would be very useful, both for creating UI, or to avoid ranges duplication between the .dsp and the rust sources.