### PR TITLE
Move the platform specific assembly build at build time

### DIFF
--- a/faust-state/src/lib.rs
+++ b/faust-state/src/lib.rs
@@ -114,33 +114,38 @@ where
 
     // Gets the fp status register.
     // Needed for flushing denormals
+    #[allow(unreachable_code)]
     fn get_fp_status_register(&self) -> Option<u32> {
+        #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
         unsafe {
-            if cfg!(any(target_arch = "arm", target_arch = "aarch64")) {
-                use std::arch::asm;
-                let fspr: u32;
-                asm!("msr fpcr, {0:r}", out(reg) fspr);
-                Some(fspr)
-            } else if cfg!(target_feature = "sse") {
-                use std::arch::x86_64::*;
-                Some(_mm_getcsr())
-            } else {
-                None
-            }
+            use std::arch::asm;
+            let fspr: u32;
+            asm!("msr fpcr, {0:r}", out(reg) fspr);
+            return Some(fspr);
         }
+        #[cfg(target_feature = "sse")]
+        unsafe {
+            use std::arch::x86_64::*;
+            return Some(_mm_getcsr());
+        }
+        None
     }
 
     // Sets the fp status register.
     // Needed for flushing denormals
+    #[allow(unreachable_code)]
     fn set_fp_status_register(&self, fspr: u32) {
+        #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
         unsafe {
-            if cfg!(any(target_arch = "arm", target_arch = "aarch64")) {
-                use std::arch::asm;
-                asm!("mrs {0:r}, fpcr", in(reg) fspr);
-            } else if cfg!(target_feature = "sse") {
-                use std::arch::x86_64::*;
-                _mm_setcsr(fspr)
-            }
+            use std::arch::asm;
+            asm!("mrs {0:r}, fpcr", in(reg) fspr);
+            return;
+        }
+        #[cfg(target_feature = "sse")]
+        unsafe {
+            use std::arch::x86_64::*;
+            _mm_setcsr(fspr);
+            return;
         }
     }
 


### PR DESCRIPTION
The conditional `if cfg!(...)` for platform specific optimization was evaluated at run time. Due to this, all the branches are compiled and the `asm!` macro fails on incompatible platform. This only happens in debug as in release the incompatible branches are optimized out early. This also used to work in previous rust versions, so possibly a change in `asm!` or in the debug optimization broke it. 

Rewrite this platform specific code in a way that everything is evaluated at build time, by having conditional blocks with early returns instead of runtime if/else.