### PR TITLE
faust-build: don't time out

### DIFF
--- a/faust-build/src/lib.rs
+++ b/faust-build/src/lib.rs
@@ -58,7 +58,9 @@ impl FaustBuilder {
             .arg("-a")
             .arg(template_file.path())
             .arg("-lang")
-            .arg("rust");
+            .arg("rust")
+            .arg("-t")
+            .arg("0");
 
         if self.use_double {
             output.arg("-double");


### PR DESCRIPTION
For bigger DSPs, like <https://github.com/magnetophon/lamb-rs>, this is needed to make it not time out while compiling.

Related: https://github.com/Frando/rust-faust/issues/23