### PR TITLE
Get ready for crates.io release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+
+# Unreleased
+
+## faust-build
+- Add `FaustBuilder::build_xml()` to generate the description file. See `faust -xml` for details. @crop2000
+- Add `FaustBuilder::set_arch_file()` to specify a custom architecture file @crop2000
+- Add `FaustBuilder::set_faust_path()` to specify a custom path to the faust binary @crop2000
+- Add `FaustBuilder::set_module_name` to specify the `mod $name` in the generated code. By default it's `dsp`. @obsoleszenz
+- Add `FaustBuilder::set_struct_name` to specify the `struct $name` in the generated code. By default it's the CamelCased file name. @obsoleszenz
+- Cleanups & refactorings to `FaustBuilder` @crop2000
+
+## faust-macro
+- New crate that implements a `proc_macro` to have faust code in your rust code.
+  See `examples/example-jack-macro/src/main.rs` for details. @olafklingt
+
+## faust-types
+- Put import of `libm` and `jack` behind a feature. Use `default-features = false` to skip this. @amomentunfolding
+
+## faust-state
+- Evaluate assembler for flushing denormals at build-time. @plule

--- a/faust-build/Cargo.toml
+++ b/faust-build/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "faust-build"
 version = "0.1.0"
-authors = ["Franz Heinzmann (Frando) <frando@unbiskant.org>"]
+authors = ["Franz Heinzmann (Frando) <frando@unbiskant.org>", "obsoleszenz <obsoleszenz@riseup.net>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/faust-macro/Cargo.toml
+++ b/faust-macro/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "faust-macro"
 version = "0.1.0"
+authors = ["olafklingt"]
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,8 +15,5 @@ proc-macro = true
 debug = []
 
 [dependencies]
-#jack = "0.7.0"
-#rtrb = "0.1.3"
 faust-build = { git = "http://github.com/Frando/rust-faust.git" }
 tempfile = "3.2.0"
-#regex = "1.10.5"

--- a/faust-types/Cargo.toml
+++ b/faust-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "faust-types"
 version = "0.1.0"
-authors = ["Franz Heinzmann (Frando) <frando@unbiskant.org>"]
+authors = ["Franz Heinzmann (Frando) <frando@unbiskant.org>", "obsoleszenz <obsoleszenz@riseup.net>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
I would like to publish `faust-types` and `faust-build` to crates.io. I would bump the version to 0.2 for them. 

Also I added a `CHANGELOG.md` file and tried to add most of the changes of the last years to it. It's really beautiful to see how much happend the last years in this project :) So thanks to all!