### PR TITLE
faust-build: don't fail on warning

### DIFF
--- a/faust-build/src/builder.rs
+++ b/faust-build/src/builder.rs
@@ -149,11 +149,9 @@ impl FaustBuilder {
             stderr
         );
 
-        assert!(
-            !stderr.contains("WARNING"),
-            "Fail on warning in stderr: \n{}",
-            stderr
-        );
+        if stderr.contains("WARNING") {
+            dbg!(stderr);
+        }
         String::from_utf8(faust_result.stdout).expect("could not parse stdout from command")
     }
 


### PR DESCRIPTION
unfortunately regular oscillators produces warnings that are expected so we cannot fail because of those.